### PR TITLE
added instructions for ocw-asb

### DIFF
--- a/04-Kubernetes-Kind-Cluster/README.md
+++ b/04-Kubernetes-Kind-Cluster/README.md
@@ -150,3 +150,18 @@ Click on the `Ports` tab in Codespaces to forward the ports
 make delete
 
 ```
+
+## Azure Secure Baseline
+
+A version of `PnP Azure Secure Baseline` is on this image in the `/workspaces` directory
+
+The rest of the hack will use this repo
+
+Run `git pull` to make sure you have the latest version
+
+```bash
+
+cd /workspaces/ocw-asb
+git pull
+
+```


### PR DESCRIPTION
- rdc/ocw-asb is cloned to /workspaces/ocw-asb during post install
- added instructions on location and to run git pull

- Closes retaildevcrews/ocw#64

